### PR TITLE
URI.encode is obsolete over Ruby 3.0

### DIFF
--- a/lib/swagger_client/api_client.rb
+++ b/lib/swagger_client/api_client.rb
@@ -266,7 +266,7 @@ module SwaggerClient
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(@config.base_url + path)
+      URI.encode_www_form(@config.base_url + path)
     end
 
     # Builds the HTTP request body

--- a/lib/swagger_client/configuration.rb
+++ b/lib/swagger_client/configuration.rb
@@ -175,7 +175,7 @@ module SwaggerClient
 
     def base_url
       url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-      URI.encode(url)
+      URI.encode_www_form(url)
     end
 
     # Gets API key (with prefix if set).


### PR DESCRIPTION
URI.escape and .encode is obsolete over Ruby 3.0.
https://docs.ruby-lang.org/ja/2.7.0/method/URI/s/escape.html

Use URI.encode_www_form instead.
https://docs.ruby-lang.org/ja/latest/method/URI/s/encode_www_form.html

Error messages in Ruby 3.1.2

```
Calling API: AuthorizationApi.authorization ...
/app/vendor/bundle/ruby/3.1.0/bundler/gems/gmo-aozora-api-ruby-3d1f16b3d8cf/lib/swagger_client/configuration.rb:178:in `base_url': undefined method `encode' for URI:Module (NoMethodError)

      URI.encode(url)
         ^^^^^^^
```
